### PR TITLE
Fixed CCM wraparound bug

### DIFF
--- a/src/dot1ag_ccd.c
+++ b/src/dot1ag_ccd.c
@@ -331,13 +331,17 @@ main(int argc, char **argv) {
 				next_ccm.tv_usec = now.tv_usec;
 			} else {
 				next_ccm.tv_sec = now.tv_sec;
-				next_ccm.tv_usec =
-					now.tv_usec + CCMinterval * 1000;
 				/* did usec counter roll over? */
 				if ((now.tv_usec + CCMinterval * 1000)
 								>= 1000000) {
 					next_ccm.tv_sec++;
+				        next_ccm.tv_usec =
+					  now.tv_usec + CCMinterval * 1000 - 1000000;
 				}
+                                else {
+				next_ccm.tv_usec =
+					now.tv_usec + CCMinterval * 1000;
+                                }
 			}
 		}
 


### PR DESCRIPTION
In the CCM transmission there was an issue with the second wraparound check.
Due to this issue, if the CCM interval was less than one second there is an occasional gap of one second without transmitting CCMs.